### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -192,7 +192,7 @@ spec:
     spec:
       containers:
       - name: baton-jamf
-        image: ghcr.io/conductorone/baton-jamf:latest
+        image: public.ecr.aws/conductorone/baton-jamf:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.